### PR TITLE
Escape column names in PRIMARY KEY constraint

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -78,7 +78,7 @@ utils.buildSchema = function(obj) {
   }));
 
   var constraints = _.compact([
-    primaryKeys.length && 'PRIMARY KEY (' + primaryKeys.join(',') + ')'
+    primaryKeys.length && 'PRIMARY KEY ("' + primaryKeys.join('","') + '")'
   ]).join(', ');
 
   return _.compact([ columns, constraints ]).join(', ');


### PR DESCRIPTION
When a column used as the primary key has a name which collides
with a reserved word the name must be escaped, otherwise the query
will cause a syntax error.
